### PR TITLE
DO-4243 removing manual reindex

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -137,18 +137,4 @@ jobs:
            INVAL_ID=$(aws cloudfront create-invalidation --distribution-id ${{ vars.CF_DISTRO }} --paths "/*" | jq -r .Invalidation.Id )
            aws cloudfront wait invalidation-completed --distribution-id ${{ vars.CF_DISTRO }} --id $INVAL_ID
 
-    - name: Setup Algolia Config
-      id: algolia_config
-      run: |
-           sed -i 's/<INDEX_NAME>/${{ vars.ENV_ALGOLIA_INDEX }}/g' algolia.json
-           sed -i 's/<FQDN>/${{ vars.FQDN }}/g' algolia.json
-           echo "::set-output name=config::$(cat algolia.json | jq -r tostring)"
-
-    - name: Run Algolia Reindex
-      uses: signcl/docsearch-scraper-action@master
-      env:
-        APPLICATION_ID: ${{ secrets.ENV_ALGOLIA_APP_ID }}
-        API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-        CONFIG: ${{ steps.algolia_config.outputs.config }}
-
 


### PR DESCRIPTION
Transition to Algolia managed DocSearch index sourcing removes the need to run a re-index after a deployment. Re-index is handled on a nightly schedule 