### PR TITLE
fix edit link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1063,7 +1063,7 @@ const config = {
         docs: {
           routeBasePath: '/',
           editUrl:
-            'https://github.com/device42/device42-docs/blob/main/',
+            'https://github.com/device42/device42-docs/edit/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
old link only works for people who have editing permission on the repo - new link prompts people to create a fork in their own account