### PR TITLE
update order of the installation section docs

### DIFF
--- a/docs/getstarted/installation/getting-started-on-a-mac.md
+++ b/docs/getstarted/installation/getting-started-on-a-mac.md
@@ -1,6 +1,6 @@
 ---
 title: "Getting Started on a Mac"
-sidebar_position: 7
+sidebar_position: 10
 ---
 
 ## From the Start - How to Setup Device42 from the Beginning on a Mac

--- a/docs/getstarted/installation/getting-started-on-a-pc.md
+++ b/docs/getstarted/installation/getting-started-on-a-pc.md
@@ -1,6 +1,6 @@
 ---
 title: "Getting Started on a PC"
-sidebar_position: 8
+sidebar_position: 11
 ---
 
 ## From the Start - How to Setup Device42 on a PC hypervisor

--- a/docs/getstarted/installation/installation-amazon-web-services.md
+++ b/docs/getstarted/installation/installation-amazon-web-services.md
@@ -1,6 +1,6 @@
 ---
 title: "Amazon Web Services - Installation"
-sidebar_position: 1
+sidebar_position: 6
 ---
 ## Device42 on AWS FAQ
 

--- a/docs/getstarted/installation/installation-citrix-xen-server.md
+++ b/docs/getstarted/installation/installation-citrix-xen-server.md
@@ -1,6 +1,6 @@
 ---
 title: "Citrix Xen Server - Installation"
-sidebar_position: 2
+sidebar_position: 8
 ---
 
 ## Installation Citrix Xen Server

--- a/docs/getstarted/installation/installation-microsoft-azure.md
+++ b/docs/getstarted/installation/installation-microsoft-azure.md
@@ -1,6 +1,6 @@
 ---
 title: "Microsoft Azure - Installation"
-sidebar_position: 4
+sidebar_position: 7
 ---
 
 ## Get Device42 from the Azure Marketplace

--- a/docs/getstarted/installation/installation-microsoft-hyperv.md
+++ b/docs/getstarted/installation/installation-microsoft-hyperv.md
@@ -1,6 +1,6 @@
 ---
 title: "Microsoft HyperV - Installation"
-sidebar_position: 5
+sidebar_position: 3
 ---
 
 ## Download the Device42 VM image & un-zip

--- a/docs/getstarted/installation/installation-vcenter-server.md
+++ b/docs/getstarted/installation/installation-vcenter-server.md
@@ -1,6 +1,6 @@
 ---
 title: "vCenter Server - Installation"
-sidebar_position: 10
+sidebar_position: 2
 ---
 
 The following simple steps in list format are followed the same steps in pictures, both of which will guide you through the import of the Device42 appliance into a vCenter Server so you can start mapping our your IT Infrastructure!

--- a/docs/getstarted/installation/installation-virtual-box.md
+++ b/docs/getstarted/installation/installation-virtual-box.md
@@ -1,6 +1,6 @@
 ---
 title: "Virtual Box - Installation"
-sidebar_position: 6
+sidebar_position: 9
 ---
 
 Instructions for installing the Device42 virtual appliance on Oracle VM Virtual Box ( Please use for trial / demo purposes **only**).

--- a/docs/getstarted/installation/installation-vmware-player.md
+++ b/docs/getstarted/installation/installation-vmware-player.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Player - Installation"
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 ## Setup appliance in vmware player or workstation

--- a/docs/getstarted/installation/installing-the-d42-netflow-collector-as-a-service.md
+++ b/docs/getstarted/installation/installing-the-d42-netflow-collector-as-a-service.md
@@ -1,6 +1,6 @@
 ---
 title: "D42 Netflow Collector - Install as Service"
-sidebar_position: 3
+sidebar_position: 15
 ---
 
 ## The Device42 Netflow Collector

--- a/docs/getstarted/installation/remote-collector-rc-installation.md
+++ b/docs/getstarted/installation/remote-collector-rc-installation.md
@@ -1,6 +1,6 @@
 ---
 title: "Remote Collector (RC) Installation"
-sidebar_position: 9
+sidebar_position: 4
 ---
 
 ## Installing the Device42 Remote Collector

--- a/docs/getstarted/installation/sizing-recommendations.md
+++ b/docs/getstarted/installation/sizing-recommendations.md
@@ -1,5 +1,6 @@
 ---
 title: "Sizing Recommendations"
+sidebar_position: 1
 ---
 
 | Device42 Item                                    | Sizing/Notes                                                                                                                                                                                                                                                                                                                                                                                                                                         |

--- a/docs/getstarted/installation/windows-discovery-service-installation.md
+++ b/docs/getstarted/installation/windows-discovery-service-installation.md
@@ -1,6 +1,6 @@
 ---
 title: "Windows Discovery Service Installation"
-sidebar_position: 12
+sidebar_position: 5
 ---
 
 - The Windows Discovery Service (WDS) should be connected directly to a Remote Collectors (RC) to enable WMI discovery directly from the Device42 UI.


### PR DESCRIPTION
Changed the order as requested:

* Sizing Recommendations. - This should include an architectural diagram and explanation of RC/WDS etc
* vCenter Server - Installation
* Microsoft HyperV - Installation
* Remote Collector (RC) Installation
* Windows Discovery Service Installation
* Amazon Web Services - Installation
* Microsoft Azure - Installation
* Citrix Xen Server - Installation
* Virtual Box - Installation
* Getting Started on a Mac
* Getting Started on a PC
* VMware Player - Installation
* Xen or KVM using virt-manager - Installation
* Xen/KVM - Import disk Alternate Install
* D42 Netflow Collector - Install as Service