### PR TITLE
1237: IPAM grammar cleanup (Week 10, 2026)

### DIFF
--- a/docs/infrastructure-management/ipam/dns-records.mdx
+++ b/docs/infrastructure-management/ipam/dns-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DNS Records"
-sidebar_position: 1
+sidebar_position: 8
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/dns-records.mdx
+++ b/docs/infrastructure-management/ipam/dns-records.mdx
@@ -6,14 +6,14 @@ sidebar_position: 8
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-A/AAAA, CNAME, MX and PTR records are supported and can be automatically populated using [DNS auto-discovery.](auto-discovery/setup-dns-autodiscovery.mdx)
+Device42 supports A/AAAA, CNAME, MX, and PTR records. Records can be added manually or populated automatically using [DNS discovery](/auto-discovery/setup-dns-autodiscovery.mdx).
 
-A/AAAA records are automatically associated with existing IP addresses (or can be associated with new IP Addresses when they are created).
+A/AAAA records are automatically associated with existing IP addresses, or can be associated with new IP addresses when they are created.
 
-You can search for records or filter by domain to edit or view certain records.
+Navigate to **Resources > DNS > All DNS Records** to view, search, and filter records by domain.
 
 <ThemedImage
-  alt="Types of DNS Records"
+  alt="DNS records list"
   sources={{
     light: useBaseUrl('/assets/images/dns-records/wpid576-Types_of_Records-light.png'),
     dark: useBaseUrl('/assets/images/dns-records/wpid576-Types_of_Records-dark.png'),

--- a/docs/infrastructure-management/ipam/dns-records.mdx
+++ b/docs/infrastructure-management/ipam/dns-records.mdx
@@ -6,7 +6,7 @@ sidebar_position: 8
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-Device42 supports A/AAAA, CNAME, MX, and PTR records. Records can be added manually or populated automatically using [DNS discovery](/auto-discovery/setup-dns-autodiscovery.mdx).
+Device42 supports A/AAAA, CNAME, MX, and PTR records. Records can be added manually or populated automatically using [DNS discovery](/auto-discovery/setup-dns-autodiscovery).
 
 A/AAAA records are automatically associated with existing IP addresses, or can be associated with new IP addresses when they are created.
 

--- a/docs/infrastructure-management/ipam/dns-records.mdx
+++ b/docs/infrastructure-management/ipam/dns-records.mdx
@@ -6,7 +6,7 @@ sidebar_position: 8
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-Device42 supports A/AAAA, CNAME, MX, and PTR records. Records can be added manually or populated automatically using [DNS discovery](/auto-discovery/setup-dns-autodiscovery).
+Device42 supports A/AAAA, CNAME, MX, and PTR records. Records can be added manually or populated automatically using [DNS discovery](auto-discovery/setup-dns-autodiscovery.mdx).
 
 A/AAAA records are automatically associated with existing IP addresses, or can be associated with new IP addresses when they are created.
 

--- a/docs/infrastructure-management/ipam/dns-zones.mdx
+++ b/docs/infrastructure-management/ipam/dns-zones.mdx
@@ -6,29 +6,29 @@ sidebar_position: 7
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-DNS zones can be added manually or (preferrably) via DNS auto-discovery as discussed at: [discovery/setup-dns-autodiscovery.mdx](auto-discovery/setup-dns-autodiscovery.mdx)
+DNS zones represent sections of the domain name space managed by a specific nameserver. Zones can be added manually or populated via [DNS discovery](/auto-discovery/setup-dns-autodiscovery.mdx).
 
-## DNS Zone Add/Edit page
+## Add a DNS Zone
 
-The DNS Zones add or edit page can be reached via the main menu, under **Resources > DNS Zones**. Click the **Create** button in the upper right to add a new zone. Give your zone a name, and specify the **Nameserver** for that zone. Optionally, you can specify the **VRF Group** that your new Zone belongs to, add **Tags** relevant to your new zone, and add any relevant **Notes**. Click **Save** in the bottom right when finished, and you'll be brought back to the DNS Zones list page, where you will see your new zone along with any others that exist.
+Navigate to **Resources > DNS > DNS Zones** and click **Create** to add a new zone.
+
+Enter a name and specify the **Nameserver** for the zone. Optionally, specify the **VRF Group** the zone belongs to, add **Tags**, and add any relevant **Notes**. Click **Save** when finished.
 
 <ThemedImage
-  alt="Add DNS Zone"
+  alt="Add DNS zone"
   sources={{
     light: useBaseUrl('/assets/images/dns-zones/add_DNS_zone-light.png'),
     dark: useBaseUrl('/assets/images/dns-zones/add_DNS_zone-dark.png'),
   }}
-  style={{ width: '70%' }} 
+  style={{ width: '70%' }}
 />
 
-To define a DNS Zone, add or edit the zone specific fields show above.
+## Edit an Existing DNS Zone
 
-## Editing existing records
-
-To edit an existing DNS Zone record (under under **Resources > DNS Zones**), click the name of the DNS Zone record you want to edit and click the **Edit** button in the upper right.
+Navigate to **Resources > DNS > DNS Zones**, click the name of the DNS zone you want to edit, then click **Edit**.
 
 <ThemedImage
-  alt="Edit DNS Zone Record"
+  alt="DNS zone records list"
   sources={{
     light: useBaseUrl('/assets/images/dns-zones/DNS_Zone_Records_List-light.png'),
     dark: useBaseUrl('/assets/images/dns-zones/DNS_Zone_Records_List-dark.png'),

--- a/docs/infrastructure-management/ipam/dns-zones.mdx
+++ b/docs/infrastructure-management/ipam/dns-zones.mdx
@@ -6,7 +6,7 @@ sidebar_position: 7
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-DNS zones represent sections of the domain name space managed by a specific nameserver. Zones can be added manually or populated via [DNS discovery](/auto-discovery/setup-dns-autodiscovery.mdx).
+DNS zones represent sections of the domain name space managed by a specific nameserver. Zones can be added manually or populated via [DNS discovery](/auto-discovery/setup-dns-autodiscovery).
 
 ## Add a DNS Zone
 

--- a/docs/infrastructure-management/ipam/dns-zones.mdx
+++ b/docs/infrastructure-management/ipam/dns-zones.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DNS Zones"
-sidebar_position: 2
+sidebar_position: 7
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/dns-zones.mdx
+++ b/docs/infrastructure-management/ipam/dns-zones.mdx
@@ -6,7 +6,7 @@ sidebar_position: 7
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-DNS zones represent sections of the domain name space managed by a specific nameserver. Zones can be added manually or populated via [DNS discovery](/auto-discovery/setup-dns-autodiscovery).
+DNS zones represent sections of the domain name space managed by a specific nameserver. Zones can be added manually or populated via [DNS discovery](auto-discovery/setup-dns-autodiscovery.mdx).
 
 ## Add a DNS Zone
 

--- a/docs/infrastructure-management/ipam/index.mdx
+++ b/docs/infrastructure-management/ipam/index.mdx
@@ -2,18 +2,18 @@
 title: "IPAM"
 ---
 
-**IP Address Management _\[aka IPAM\]_** software helps IT systems admins track and manage the IP addresses in their computer networks.
+Device42's IP Address Management (IPAM) module lets you track and manage IP addresses, subnets, VLANs, VRF groups, DNS records, switch ports, and NAT mappings across your network infrastructure.
 
-[IP Address Management (IPAM)](https://www.device42.com/features/ip-address-management/) is an essential part of Device42. With Device42's comprehensive network autodiscovery, it's never been easier to maintain up-to-date documentation of your IP Addresses, MAC Addresses, and DNS Infrastructure. In this section, we will cover VLAN, Subnet, IP Address, MAC Address, Switch Port Connectivity, and IP NATs.
+This section covers how to organize your address space with VRF groups and VLANs, manage subnets and individual IP addresses, configure DNS zones and records, and work with switch port connectivity. Most IPAM data is populated automatically through network discovery, but you can also add and edit entries manually.
 
-## Discovering IP Addresses
+## Discover IP Addresses
 
-There are multiple ways Device42 can discover IP Addresses and related information:
+Device42 can discover IP addresses and related network information through several methods:
 
-- [Network SNMP Discovery](/auto-discovery/network-auto-discovery.mdx): Configuring and running SNMP autodiscovery to gather subnets, IP to MAC Address relationships, and MAC Address to Switch Port relationship information.
-- [Device42's Auto Discovery](/auto-discovery/windows-and-hyper-v-auto-discovery.mdx): Using the autodiscovery client to discover Microsoft Windows and Linux and/or UNIX devices on your network, including their IP and MAC Address details.
-- [Device42's Ping Sweep Tool](/auto-discovery/d42-ping-sweep.mdx): This page details usage of the ping sweep utility to keep your IP Address information up-to-date.
+- [Network SNMP Discovery](/auto-discovery/network-auto-discovery.mdx): Discover subnets, IP-to-MAC address relationships, and MAC-to-switch-port connectivity.
+- [Windows and Hyper-V Discovery](/auto-discovery/windows-and-hyper-v-auto-discovery.mdx): Discover Windows, Linux, and UNIX devices on your network, including their IP and MAC address details.
+- [Ping Sweep](/auto-discovery/d42-ping-sweep.mdx): Keep your IP address records up to date by sweeping address ranges for active hosts.
 
-## Importing IP addresses into Device42
+## Import IP Addresses
 
-Importing existing IP addresses from [Microsoft Excel & CSV spreadsheets](/getstarted/using-device42/importing-data-from-existing-spreadsheets.mdx) is easy - Take advantage of this powerful feature to import existing IP Address data from MS Excel and/or .CSV _\[Comma Separated Value\]_ spreadsheets into Device42 IPAM.
+You can import existing IP address data from Microsoft Excel or CSV spreadsheets. See [Importing Data From Existing Spreadsheets](/getstarted/using-device42/importing-data-from-existing-spreadsheets.mdx) for instructions.

--- a/docs/infrastructure-management/ipam/index.mdx
+++ b/docs/infrastructure-management/ipam/index.mdx
@@ -10,10 +10,10 @@ This section covers how to organize your address space with VRF groups and VLANs
 
 Device42 can discover IP addresses and related network information through several methods:
 
-- [Network SNMP Discovery](/auto-discovery/network-auto-discovery.mdx): Discover subnets, IP-to-MAC address relationships, and MAC-to-switch-port connectivity.
-- [Windows and Hyper-V Discovery](/auto-discovery/windows-and-hyper-v-auto-discovery.mdx): Discover Windows, Linux, and UNIX devices on your network, including their IP and MAC address details.
-- [Ping Sweep](/auto-discovery/d42-ping-sweep.mdx): Keep your IP address records up to date by sweeping address ranges for active hosts.
+- [Network SNMP Discovery](/auto-discovery/network-auto-discovery): Discover subnets, IP-to-MAC address relationships, and MAC-to-switch-port connectivity.
+- [Windows and Hyper-V Discovery](/auto-discovery/windows-and-hyper-v-auto-discovery): Discover Windows, Linux, and UNIX devices on your network, including their IP and MAC address details.
+- [Ping Sweep](/auto-discovery/d42-ping-sweep): Keep your IP address records up to date by sweeping address ranges for active hosts.
 
 ## Import IP Addresses
 
-You can import existing IP address data from Microsoft Excel or CSV spreadsheets. See [Importing Data From Existing Spreadsheets](/getstarted/using-device42/importing-data-from-existing-spreadsheets.mdx) for instructions.
+You can import existing IP address data from Microsoft Excel or CSV spreadsheets. See [Importing Data From Existing Spreadsheets](/getstarted/using-device42/importing-data-from-existing-spreadsheets) for instructions.

--- a/docs/infrastructure-management/ipam/index.mdx
+++ b/docs/infrastructure-management/ipam/index.mdx
@@ -10,10 +10,10 @@ This section covers how to organize your address space with VRF groups and VLANs
 
 Device42 can discover IP addresses and related network information through several methods:
 
-- [Network SNMP Discovery](/auto-discovery/network-auto-discovery): Discover subnets, IP-to-MAC address relationships, and MAC-to-switch-port connectivity.
-- [Windows and Hyper-V Discovery](/auto-discovery/windows-and-hyper-v-auto-discovery): Discover Windows, Linux, and UNIX devices on your network, including their IP and MAC address details.
-- [Ping Sweep](/auto-discovery/d42-ping-sweep): Keep your IP address records up to date by sweeping address ranges for active hosts.
+- [Network SNMP Discovery](auto-discovery/network-auto-discovery.mdx): Discover subnets, IP-to-MAC address relationships, and MAC-to-switch-port connectivity.
+- [Windows and Hyper-V Discovery](auto-discovery/windows-and-hyper-v-auto-discovery.mdx): Discover Windows, Linux, and UNIX devices on your network, including their IP and MAC address details.
+- [Ping Sweep](auto-discovery/d42-ping-sweep.mdx): Keep your IP address records up to date by sweeping address ranges for active hosts.
 
 ## Import IP Addresses
 
-You can import existing IP address data from Microsoft Excel or CSV spreadsheets. See [Importing Data From Existing Spreadsheets](/getstarted/using-device42/importing-data-from-existing-spreadsheets) for instructions.
+You can import existing IP address data from Microsoft Excel or CSV spreadsheets. See [Importing Data From Existing Spreadsheets](getstarted/using-device42/importing-data-from-existing-spreadsheets.mdx) for instructions.

--- a/docs/infrastructure-management/ipam/ip-addresses.mdx
+++ b/docs/infrastructure-management/ipam/ip-addresses.mdx
@@ -66,7 +66,7 @@ View the history of changes from the **History (Audit Logs)** tab at the top of 
 The **Resource** field links to the Kubernetes cluster that is currently holding that IP.
 
 :::note
-The **Configuration Resource** and **Configuration Resource Item** fields apply only to Kubernetes cloud discovery jobs (see [cloud platforms discovery](/auto-discovery/cloud-auto-discovery/index.mdx)) and are populated automatically. Do not populate these fields for a regular IP address.
+The **Configuration Resource** and **Configuration Resource Item** fields apply only to Kubernetes cloud discovery jobs (see [cloud platforms discovery](/auto-discovery/cloud-auto-discovery/index)) and are populated automatically. Do not populate these fields for a regular IP address.
 :::
 
 ### Add an IP Address

--- a/docs/infrastructure-management/ipam/ip-addresses.mdx
+++ b/docs/infrastructure-management/ipam/ip-addresses.mdx
@@ -6,17 +6,15 @@ sidebar_position: 5
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-IP Addresses in the Device42 database must be unique per VRF group. So, you can have two subnets with overlapping IP ranges as long as they are in different VRF groups. The only issue with overlapping subnet ranges is that autodiscovery and import will add or modify the IP into first subnet it finds in the list.
+IP addresses in Device42 must be unique per VRF group. You can have two subnets with overlapping IP ranges as long as they are in different VRF groups. With overlapping subnet ranges, discovery and import will add or modify the IP in the first matching subnet found in the list.
 
-Device42 can return information about IP addresses that are associated with multiple devices. The IP list page now includes a **Devices** column displaying the device or devices associated with an IP (in comma-separated format). You can also use the IP edit page to add or delete devices associated with an IP address as shown in the [Add/Edit Page](#addedit-page) section below.
+The IP list page includes a **Devices** column displaying all devices associated with an IP in comma-separated format. You can also add or remove device associations from the IP edit page.
 
 ## IP Addresses List Page
 
-Navigate to the IP Addresses list page by going to **Resources > IPs > All IP Addresses**.
+Navigate to **Resources > IPs > All IP Addresses** to view the IP addresses list page.
 
-The list page shows IPv4 and IPv6 addresses that you can sort by any field. You can also filter by type, availability, updated time stamp, subnet, VRF group, and tags.
-
-You can search for IPs with full or partial entries right here. Clicking on an IP takes you to its view page.
+The list page shows IPv4 and IPv6 addresses that you can sort by any field. You can also filter by type, availability, updated time stamp, subnet, VRF group, and tags. Search for IPs with full or partial entries, and click on any IP to view its details.
 
 <ThemedImage
   alt="IP Addresses list page"
@@ -28,7 +26,7 @@ You can search for IPs with full or partial entries right here. Clicking on an I
 
 ### Bulk Actions for IP Addresses
 
-To perform a bulk action, check the IP addresses to affect from the list and select an action from the **Select an action** dropdown menu. Then confirm the action in the dialog to perform the selected bulk action.
+Select IP addresses from the list, choose an action from the **Select an action** dropdown menu, and confirm in the dialog.
 
 <ThemedImage
   alt="Bulk actions menu"
@@ -37,22 +35,21 @@ To perform a bulk action, check the IP addresses to affect from the list and sel
     dark: useBaseUrl('/assets/images/ipam-ip-addresses/bulk-actions-menu-dark.png'),
   }}
 />
-<br/><br/>
 
-The following bulk actions are available for IP addresses:
+The following bulk actions are available:
 
-- **Export selected items to CSV**: Create CSV export file. 
-- **Do a re-importable export for selected items**: Create an export file that you can re-import.
-- **Delete with Detailed Confirmation:** Displays prompt before deleting. 
-- **Fast Background Delete**: Delete without prompt. 
-- **Mark selected IP as available:** Will only mark those IPs available that have no device association. 
-- **Mark selected IPs as not available**: Will mark selected IPs as not available. 
-- **Clear ALL fields and Mark selected IPs as available**: This command will clear all device associations for the selected IPs and mark those IPs as available. 
-- **Relocate Selected IPs**: This will bring up a matching subnets page based on the first selected IPs. You can choose to move IPs to another subnet with this. Only IPs that are within the range will be moved. 
-- **Add tags to selected items**: add a comma-separated list of tags. 
-- **Check/Fix selected IPs Subnet assignment**: Displays a page to check or fix the Subnet assignment.
+- **Export selected items to CSV:** Create a CSV export file.
+- **Do a re-importable export for selected items:** Create an export file that you can re-import.
+- **Delete with Detailed Confirmation:** Display a prompt before deleting.
+- **Fast Background Delete:** Delete without a prompt.
+- **Mark selected IP as available:** Mark IPs as available only if they have no device association.
+- **Mark selected IPs as not available:** Mark selected IPs as not available.
+- **Clear ALL fields and Mark selected IPs as available:** Clear all device associations for the selected IPs and mark them as available.
+- **Relocate Selected IPs:** Display a matching subnets page based on the selected IPs. Only IPs within the target subnet range will be moved.
+- **Add tags to selected items:** Add a comma-separated list of tags.
+- **Check/Fix selected IPs Subnet assignment:** Display a page to check or fix the subnet assignment.
 
-### View IP Address Page
+### View an IP Address
 
 Click on an IP address to view its details.
 
@@ -63,19 +60,18 @@ Click on an IP address to view its details.
     dark: useBaseUrl('/assets/images/ipam-ip-addresses/view-ip-address-dark.png'),
   }}
 />
-<br/><br/>
 
-You can see the history of changes for that IP address from the **History (Audit Logs)** tab at the top of the page (similar to all other view pages in the application). If you have appropriate permissions, the **Edit** button will be available. All DNS records that use this IP are shown in the view page as well.
+View the history of changes from the **History (Audit Logs)** tab at the top of the page. If you have appropriate permissions, the **Edit** button is available. All DNS records that use this IP are shown on the view page as well.
 
-Clicking on the link in the **Resource** field will take you to the K8s cluster that is currently holding that IP.
+The **Resource** field links to the Kubernetes cluster that is currently holding that IP.
 
 :::note
-Entries in the **Configuration Resource** and **Configuration Resource Item** fields make sense only in the context of a Kubernetes cloud discovery job ([cloud platforms autodiscovery](auto-discovery/cloud-auto-discovery/index.mdx)) and are filled in automatically. These fields should not be populated for a regular IP address.
+The **Configuration Resource** and **Configuration Resource Item** fields apply only to Kubernetes cloud discovery jobs (see [cloud platforms discovery](/auto-discovery/cloud-auto-discovery/index.mdx)) and are populated automatically. Do not populate these fields for a regular IP address.
 :::
 
 ### Add an IP Address
 
-Click on the **Create** button on the view page to add an IP address.
+Click **Create** on the list page to add a new IP address.
 
 <ThemedImage
   alt="Add IP address button"
@@ -84,9 +80,8 @@ Click on the **Create** button on the view page to add an IP address.
     dark: useBaseUrl('/assets/images/ipam-ip-addresses/add-ip-button-dark.png'),
   }}
 />
-<br/><br/>
 
-When adding or editing an IP, the Subnet field is required. Device42 will automatically check if the IP falls within the allowed IP range in the subnet and will not allow duplicate IPs to be added in that VRF group or subnet (if not a VRF group). You can choose an existing device and port or add new ones from this page.
+The **Subnet** field is required. Device42 automatically checks that the IP falls within the allowed range in the subnet and prevents duplicate IPs within the same VRF group or subnet. You can choose an existing device and port or add new ones from this page.
 
 <ThemedImage
   alt="Add IP address form"
@@ -95,25 +90,23 @@ When adding or editing an IP, the Subnet field is required. Device42 will automa
     dark: useBaseUrl('/assets/images/ipam-ip-addresses/add-ip-address-form-dark.png'),
   }}
 />
-<br/><br/>
 
 ## Associate Devices With an IP Address
 
-To enter additional device(s) to associate with an already-created IP address, click on the **Edit** button of the IP address from its view page. Then click on the **+ Add New** button.
+To associate additional devices with an existing IP address, click **Edit** on the IP address view page, then click **+ Add New**.
 
 <ThemedImage
-  alt="Add device from editing view"
+  alt="Add device association"
   sources={{
     light: useBaseUrl('/assets/images/ipam-ip-addresses/add-device-association-light.png'),
     dark: useBaseUrl('/assets/images/ipam-ip-addresses/add-device-association-dark.png'),
   }}
 />
-<br/><br/>
 
 :::tip
-Select **Resources > DNS > All DNS Records** from the main menu to add DNS A/AAAA records for the IP and they will be updated on the IP address.
+Navigate to **Resources > DNS > All DNS Records** to add DNS A or AAAA records for the IP. The records will be reflected on the IP address view page.
 :::
 
-## IP Address Management from the Command Line
+## Manage IP Addresses from the Command Line
 
-With Device42, you can find if an IP is already in a D42 instance, suggest the next available IP, and add an IP from the command line using the REST APIs. Here is a post discussing this: [https://www.device42.com/blog/2013/03/27/ip-address-management-from-the-command-line/](https://www.device42.com/blog/2013/03/27/ip-address-management-from-the-command-line/)
+You can check whether an IP exists, suggest the next available IP, and add an IP from the command line using the [Device42 REST APIs](https://api.device42.com/).

--- a/docs/infrastructure-management/ipam/ip-addresses.mdx
+++ b/docs/infrastructure-management/ipam/ip-addresses.mdx
@@ -1,6 +1,6 @@
 ---
 title: "IP Addresses"
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/ip-addresses.mdx
+++ b/docs/infrastructure-management/ipam/ip-addresses.mdx
@@ -66,7 +66,7 @@ View the history of changes from the **History (Audit Logs)** tab at the top of 
 The **Resource** field links to the Kubernetes cluster that is currently holding that IP.
 
 :::note
-The **Configuration Resource** and **Configuration Resource Item** fields apply only to Kubernetes cloud discovery jobs (see [cloud platforms discovery](/auto-discovery/cloud-auto-discovery/index)) and are populated automatically. Do not populate these fields for a regular IP address.
+The **Configuration Resource** and **Configuration Resource Item** fields apply only to Kubernetes cloud discovery jobs (see [cloud platforms discovery](auto-discovery/cloud-auto-discovery/index.mdx)) and are populated automatically. Do not populate these fields for a regular IP address.
 :::
 
 ### Add an IP Address

--- a/docs/infrastructure-management/ipam/ip-nat-map.mdx
+++ b/docs/infrastructure-management/ipam/ip-nat-map.mdx
@@ -6,19 +6,21 @@ sidebar_position: 6
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-IP Nat/Map functions are used for routing, such as routing external IPs to internal IPs or routing traffic within different network segments. You define IP Nat/Maps as they are not found during discovery.
+IP NAT/Map entries define network address translation (NAT) mappings, such as routing external IPs to internal IPs or routing traffic between different network segments. NAT mappings are not found during discovery and must be defined manually.
 
-- To create an IP Nat/Map, go to **Resources > IPs > IP NAT** to display Nat/Map list page, and then click **Create** at the top right.
+## Create an IP NAT/Map
+
+Navigate to **Resources > IPs > IP NAT** to display the NAT/Map list page, then click **Create**.
 
 <ThemedImage
-  alt="IP NAT/Map menu"
+  alt="IP NAT/Map list page"
   sources={{
     light: useBaseUrl('/assets/images/ip-nat-map/WEB-597_ip-nat-map-menu-1-700x351-light.png'),
     dark: useBaseUrl('/assets/images/ip-nat-map/WEB-597_ip-nat-map-menu-1-700x351-dark.png'),
   }}
 />
 
-Device42 displays the Nat/Map add page.
+Enter a **Name** for the NAT/Map, then enter the **Source IP Address Start** and **Target IP Address Start**. You can also use the **plus icon** to select an IP address.
 
 <ThemedImage
   alt="IP NAT/Map add page"
@@ -28,8 +30,6 @@ Device42 displays the Nat/Map add page.
   }}
 />
 
-- Enter a **Name** for the Nat/Map, and then enter the **Source IP Address Start** and **Target IP Address Start**. You can also use the plus icon to select an IP address.
-
 <ThemedImage
   alt="Select IP address"
   sources={{
@@ -38,15 +38,15 @@ Device42 displays the Nat/Map add page.
   }}
 />
 
-- You can also select or enter these options:
+The following optional fields are also available:
 
-    - **Two way relation**
-    - **Protocol**
-    - **Source IP Address End**
-    - **Source Port Stat**
-    - **Source Port End**
-    - **Target IP Address End**
-    - **Target Port Start**
-    - **Target Port End**
+- **Two Way Relation**
+- **Protocol**
+- **Source IP Address End**
+- **Source Port Start**
+- **Source Port End**
+- **Target IP Address End**
+- **Target Port Start**
+- **Target Port End**
 
-- When done, click **Save**. The IP Nat/Map is added to the list.
+Click **Save** to add the IP NAT/Map to the list.

--- a/docs/infrastructure-management/ipam/ip-nat-map.mdx
+++ b/docs/infrastructure-management/ipam/ip-nat-map.mdx
@@ -1,6 +1,6 @@
 ---
 title: "IP NAT/Map"
-sidebar_position: 4
+sidebar_position: 6
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/subnet-tree-view.mdx
+++ b/docs/infrastructure-management/ipam/subnet-tree-view.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Subnet Tree View"
-sidebar_position: 6
+sidebar_position: 4
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/subnet-tree-view.mdx
+++ b/docs/infrastructure-management/ipam/subnet-tree-view.mdx
@@ -6,116 +6,100 @@ sidebar_position: 4
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-A subnet tree view is available under **Resources > Networks > Subnet Tree**.
+The subnet tree view provides a visual, hierarchical display of your subnets organized by VRF group. From the tree view, you can add, edit, nest, and relocate subnets and IPs without navigating away from the page.
 
-## Subnet Tree View
+Navigate to **Resources > Networks > Subnet Tree** to open the tree view.
 
 <ThemedImage
-  alt="Subnet Tree View"
+  alt="Subnet tree view"
   sources={{
     light: useBaseUrl('/assets/images/subnet-tree-view/subnet_tree_view-1512-light.png'),
     dark: useBaseUrl('/assets/images/subnet-tree-view/subnet_tree_view-1512-dark.png'),
   }}
 />
 
-Subnets in the tree view are grouped into VRF groups. Because VRF groups have building associations, VRF group display also contains the building name.
+Subnets in the tree view are grouped into VRF groups. Because VRF groups have building associations, the VRF group display also includes the building name.
 
-New subnets can be added to a VRF group by hovering over a VRF group and clicking the **+ New Subnet** button.
+Add new subnets to a VRF group by hovering over it and clicking the **+ New Subnet** button.
 
-## Hover for details pop-up
+## Hover for Details
+
+Hover your mouse over any VRF group, subnet, or IP to see more details. The subnet details include a small graph showing the percentage of IP addresses used.
 
 <ThemedImage
-  alt="subnet tree hover details"
+  alt="Subnet tree hover details"
   sources={{
     light: useBaseUrl('/assets/images/subnet-tree-view/hover_subnet_tree-light.png'),
     dark: useBaseUrl('/assets/images/subnet-tree-view/hover_subnet_tree-dark.png'),
   }}
-  style={{ width: '80%' }} 
+  style={{ width: '80%' }}
 />
 
-You can hover your mouse over any VRF groups, subnet, or IP and get more details on each. The subnet details includes a small graph that indicates the Percentage (%) of IP addresses used.
+Each subnet and VRF group has an **Edit** button next to it for making changes directly from the tree view.
 
-Each subnet and VRF group has an **Edit** button next to it. Click it to make changes from the subnet tree view.
+## Add or Edit IPs
 
-## Add / edit IPs per subnet
-
-<ThemedImage
-  alt="Add / edit IPs per subnet"
-  sources={{
-    light: useBaseUrl('/assets/images/subnet-tree-view/wpid6691-media_1424648468104-light.png'),
-    dark: useBaseUrl('/assets/images/subnet-tree-view/wpid6691-media_1424648468104-dark.png'),
-  }}
-/>
-
-Using the **+ New IP** button after each subnet, you can add a new IP. If the subnet is smaller than 24 mask bits, you will see a list of all IPs that don’t exist yet in that subnet and you can just pick one for the list.  For larger subnets you will be presented with a dialog to let you enter the information directly.
-
-Also, next to each IP, you will see an **Edit** button that will enable you to edit the IP right from this page.
-
-## Nest subnets right from the tree view
+Use the **+ New IP** button next to each subnet to add a new IP. For subnets smaller than `/24`, a list of all unused IPs in that subnet is displayed for selection. For larger subnets, you are presented with the **Add IP Address** dialog to enter the details directly.
 
 <ThemedImage
-  alt="Nest subnets right from the tree view"
-  sources={{
-    light: useBaseUrl('/assets/images/subnet-tree-view/wpid6689-media_1424645974037-light.png'),
-    dark: useBaseUrl('/assets/images/subnet-tree-view/wpid6689-media_1424645974037-dark.png'),
-  }}
-/>
-
-You can also nest subnets right from the tree view using the **+ New Subnet** button after each subnet. If you click this button, you get a tree like view of available subnets within that subnet that you can click on and choose. You can also drag and drop subnets into another subnet or another VRF group.
-
-:::info
-Please note that the drag and drop functionality is disabled for trees with over 2000 subnets.
-:::
-
-## View Available Subnets
-
-When adding subnets, you can view used and available subnets at a glance by clicking the **Subnet Usage Tree** button:
-
-<ThemedImage
-  alt="View available subnets from the tree view"
-  sources={{
-    light: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-1-light.png'),
-    dark: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-1-dark.png'),
-  }}
-/>
-
-In the example above, you see the available subnets for the selected parent subnet. You will see the available subnets in green and the used (or partially used subnets) in red. You can drill further into the subnet tree by clicking **Expand All**:
-
-<ThemedImage
-  alt="View available subnets from the tree view"
-  sources={{
-    light: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-2-light.png'),
-    dark: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-2-dark.png'),
-  }}
-  style={{ width: '80%' }} 
-/>
-
-These views will help you decide which subnet to assign.
-
-## Suggest a Subnet
-
-When you choose a subnet to assign, the subnet you choose will have a big impact on future subnets choices. If you choose a subnet that is much bigger than you need, then many of its subnet are in effect wasted. If you choose a subnet that is near another subnet but not directly adjacent, the available subnets in between may be too small to be used and are effectively wasted. The goal is always to choose subnets that maximize future flexibility in subnet selection and assignment.
-
-Device42 offers a patent-pending recommendation engine for choosing subnets. Just enter the desired **Mask Bits** and click the **Suggest Subnet** button and Device42 will calculate the optimal subnet. You will be presented with two options to ignore parent subnets that are merged as Assigned or Allocated even if they are still empty. Once you click the **Run** button, Device42 will present its suggestion for you to accept or decline.
-
-<ThemedImage
-  alt="Recommend a subnet from the tree view"
-  sources={{
-    light: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-suggest-1-light.png'),
-    dark: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-suggest-1-dark.png'),
-  }}
-/>
-
-## Add new IPs from the tree view
-
-<ThemedImage
-  alt="Add new IPs from the tree view"
+  alt="Add or edit IPs per subnet"
   sources={{
     light: useBaseUrl('/assets/images/subnet-tree-view/wpid6690-media_1424646022240-light.png'),
     dark: useBaseUrl('/assets/images/subnet-tree-view/wpid6690-media_1424646022240-dark.png'),
   }}
 />
 
-Using the **+ New IP** button after each subnet, you can add a new IP. If the subnet is smaller than 24 mask bits, then you will see a list of all IPs that don’t exist yet in that subnet and you can just pick one for the list.  If the subnet is larger, you will go directly to the **Add IP Address** dialog where you can enter all the details directly.
+Each IP also has an **Edit** button next to it for making changes from this page.
 
-Also, next to each IP, you will see a **Edit** button that will enable you to edit the IP right from this page.
+## Nest Subnets
+
+Use the **+ New Subnet** button next to each subnet to create a nested subnet. Clicking this button displays a tree-like view of available subnets within that subnet to choose from. You can also drag and drop subnets into another subnet or another VRF group.
+
+<ThemedImage
+  alt="Nest subnets from tree view"
+  sources={{
+    light: useBaseUrl('/assets/images/subnet-tree-view/wpid6689-media_1424645974037-light.png'),
+    dark: useBaseUrl('/assets/images/subnet-tree-view/wpid6689-media_1424645974037-dark.png'),
+  }}
+/>
+
+:::info
+Drag-and-drop functionality is disabled for trees with over 2,000 subnets.
+:::
+
+## View Available Subnets
+
+Click the **Subnet Usage Tree** button to view used and available subnets at a glance.
+
+<ThemedImage
+  alt="View available subnets"
+  sources={{
+    light: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-1-light.png'),
+    dark: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-1-dark.png'),
+  }}
+/>
+
+Available subnets are shown in green and used (or partially used) subnets are shown in red. Click **Expand All** to drill further into the subnet tree.
+
+<ThemedImage
+  alt="Expanded available subnets"
+  sources={{
+    light: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-2-light.png'),
+    dark: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-availability-2-dark.png'),
+  }}
+  style={{ width: '80%' }}
+/>
+
+## Suggest a Subnet
+
+Choosing the right subnet size and position matters. A subnet that is much bigger than needed wastes address space. A subnet that is near but not adjacent to another can leave unusable gaps. The goal is to maximize future flexibility in subnet selection and assignment.
+
+Device42 offers a recommendation engine for choosing subnets. Enter the desired **Mask Bits** and click the **Suggest Subnet** button. You can optionally ignore parent subnets marked as Assigned or Allocated even if they are still empty. Click **Run** and Device42 will present its suggestion for you to accept or decline.
+
+<ThemedImage
+  alt="Suggest a subnet"
+  sources={{
+    light: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-suggest-1-light.png'),
+    dark: useBaseUrl('/assets/images/subnet-tree-view/subnet-tree-suggest-1-dark.png'),
+  }}
+/>

--- a/docs/infrastructure-management/ipam/subnet-tree-view.mdx
+++ b/docs/infrastructure-management/ipam/subnet-tree-view.mdx
@@ -53,7 +53,7 @@ Each IP also has an **Edit** button next to it for making changes from this page
 
 ## Nest Subnets
 
-Use the **+ New Subnet** button next to each subnet to create a nested subnet. Clicking this button displays a tree-like view of available subnets within that subnet to choose from. You can also drag and drop subnets into another subnet or another VRF group.
+Use the **+ New Subnet** button next to each subnet to create a nested subnet. Clicking this button displays a tree-like view of available subnets within that subnet to choose from. You can also drag and drop subnets into another subnet or another VRF group. Drag and drop is disabled for trees with over 2000 subnets.
 
 <ThemedImage
   alt="Nest subnets from tree view"

--- a/docs/infrastructure-management/ipam/subnets.mdx
+++ b/docs/infrastructure-management/ipam/subnets.mdx
@@ -8,7 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 A subnet can be any Layer 3 network (IPv4 or IPv6) in your organization, and it can optionally be part of a VLAN. All IP addresses in Device42 must belong to a subnet.
 
-You can create nested subnets automatically and relocate manually created subnets as nested subnets. The subnet must be part of a [VRF group](vrf-groups.mdx) to create nested subnets.
+You can create nested subnets automatically and relocate manually created subnets as nested subnets. The subnet must be part of a [VRF group](vrf-groups.mdx) to create nested subnets. When you add an overlapping subnet within a VRF group, it is automatically positioned with the correct parent-child relationship.
 
 ## Subnet List Page
 
@@ -118,10 +118,6 @@ A VRF group is required if you want to further subnet this subnet.
 The **Subnet Category** field can be used to categorize your subnets. If you use the Multitenancy feature, you can restrict subnet permissions based on these categories.
 
 If you mark the network or broadcast addresses as usable for a subnet, these IPs will appear as usable on the IP address list page.
-
-## VRF Groups and Overlapping Subnet Ranges
-
-When you add an overlapping subnet within a VRF group, the subnet is automatically positioned with the correct parent-child relationship.
 
 ## Add Nested Subnets
 

--- a/docs/infrastructure-management/ipam/subnets.mdx
+++ b/docs/infrastructure-management/ipam/subnets.mdx
@@ -8,7 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 A subnet can be any Layer 3 network (IPv4 or IPv6) in your organization, and it can optionally be part of a VLAN. All IP addresses in Device42 must belong to a subnet.
 
-You can create nested subnets automatically and relocate manually created subnets as nested subnets. The subnet must be part of a [VRF group](vrf-groups.mdx) to create nested subnets. When you add an overlapping subnet within a VRF group, it is automatically positioned with the correct parent-child relationship.
+You can create nested subnets automatically and relocate manually created subnets as nested subnets. The subnet must be part of a [VRF group](/infrastructure-management/ipam/vrf-groups) to create nested subnets. When you add an overlapping subnet within a VRF group, it is automatically positioned with the correct parent-child relationship.
 
 ## Subnet List Page
 

--- a/docs/infrastructure-management/ipam/subnets.mdx
+++ b/docs/infrastructure-management/ipam/subnets.mdx
@@ -6,30 +6,26 @@ sidebar_position: 3
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-A subnet can be any L3 network (IPv4 or IPv6) in your organization, and it can be part of a VLAN or not. All IP Addresses in Device42 must belong to a subnet.
+A subnet can be any Layer 3 network (IPv4 or IPv6) in your organization, and it can optionally be part of a VLAN. All IP addresses in Device42 must belong to a subnet.
 
-You can create nested subnets automatically and can relocate manually created subnets as a nested subnet.
-
-The subnet must be part of a VRF group to create a nested subnet.
+You can create nested subnets automatically and relocate manually created subnets as nested subnets. The subnet must be part of a [VRF group](vrf-groups.mdx) to create nested subnets.
 
 ## Subnet List Page
 
+Navigate to **Resources > Networks > All Subnets** to view all defined and discovered subnets. You can sort by multiple fields.
+
 <ThemedImage
-  alt="Subnet List page"
+  alt="Subnet list page"
   sources={{
     light: useBaseUrl('/assets/images/subnets/WEB-833_1-light.png'),
     dark: useBaseUrl('/assets/images/subnets/WEB-833_1-dark.png'),
   }}
 />
 
-This page lists all your defined and discovered subnets. As with any list, you can sort by multiple fields.
+- **% Used:** Shows how much of the subnet space is in use, giving you an idea of whether available IPs are being exhausted. This applies to IPv4 subnets only.
+- **Show IPs:** Takes you to the IP address page filtered to show all IP addresses in that subnet.
 
-Here are a few useful tips:
-
-1. **% Used** indicates how much of the subnet space is used and gives you an idea of whether a subnet is being exhausted for available IPs. This only applies to IPv4 subnets.
-2. **Show IPs** takes you to the IP address page and shows you all IP addresses that belong to this subnet.
-
-Clicking on a subnet gives you a detailed view/edit page for that subnet.
+Click on a subnet to view its details and edit page.
 
 <ThemedImage
   alt="Subnet detailed view"
@@ -39,128 +35,128 @@ Clicking on a subnet gives you a detailed view/edit page for that subnet.
   }}
 />
 
-### Actions: Deleting Subnets
+### Subnet Actions
 
-You can add IPs to an existing subnet using the new **Background Populate Subnets with IPs** command from the Subnet's **Actions** menu. 
+The **Actions** menu on the subnet list page includes several bulk operations.
 
-- When deleting a subnet (**Delete with Detailed Confirmation**), you can also choose to add the associated IPs to the parent subnet (if one exists). This feature helps when doing maintenance on subnets, where it is desirable to move from a smaller to a larger subnet without removing or recreating the associated IP addresses.
-
-  <ThemedImage
-    alt="Subnet Action menu"
-    sources={{
-      light: useBaseUrl('/assets/images/subnets/WEB-833_3-light.png'),
-      dark: useBaseUrl('/assets/images/subnets/WEB-833_3-dark.png'),
-    }}
-  />
- 
-
-  <ThemedImage
-    alt="Background Populate Subnets"
-    sources={{
-      light: useBaseUrl('/assets/images/subnets/WEB-833_4-light.png'),
-      dark: useBaseUrl('/assets/images/subnets/WEB-833_4-dark.png'),
-    }}
-  />
-
-
-  <ThemedImage
-    alt="Delete with Detailed Confirmation"
-    sources={{
-      light: useBaseUrl('/assets/images/subnets/WEB-833_5-light.png'),
-      dark: useBaseUrl('/assets/images/subnets/WEB-833_5-dark.png'),
-    }}
-  />
-
-### Actions: Creating a Ping Sweep Job
-
-- The **Actions** menu also includes an option for creating a ping sweep job for a set of selected subnets.
-
-  <ThemedImage
-    alt="Ping sweep action"
-    sources={{
-      light: useBaseUrl('/assets/images/subnets/ping-sweep-action-light.png'),
-      dark: useBaseUrl('/assets/images/subnets/ping-sweep-action-dark.png'),
-    }}
-  />
-
-- Click on the **View details** link on the green success message to see the details of the newly created ping sweep job. You can also view the job under **Discovery > Ping Sweep**.
-
-  <ThemedImage
-    alt="View details link"
-    sources={{
-      light: useBaseUrl('/assets/images/subnets/ping-sweep-toast-link-light.png'),
-      dark: useBaseUrl('/assets/images/subnets/ping-sweep-toast-link-dark.png'),
-    }}
-  />
-
-- Run the ad hoc ping sweep job immediately using the **Run Now** button on the details page. 
-
-  <ThemedImage
-    alt="View Adhoc ping sweep"
-    sources={{
-      light: useBaseUrl('/assets/images/subnets/adhoc-ping-sweep-light.png'),
-      dark: useBaseUrl('/assets/images/subnets/adhoc-ping-sweep-dark.png'),
-    }}
-  />
-
-## Adding or Editing a Subnet
+You can add IPs to an existing subnet using the **Background Populate Subnets with IPs** command.
 
 <ThemedImage
-  alt="Adding/Editing a subnet"
+  alt="Subnet Action menu"
+  sources={{
+    light: useBaseUrl('/assets/images/subnets/WEB-833_3-light.png'),
+    dark: useBaseUrl('/assets/images/subnets/WEB-833_3-dark.png'),
+  }}
+/>
+
+<ThemedImage
+  alt="Background Populate Subnets"
+  sources={{
+    light: useBaseUrl('/assets/images/subnets/WEB-833_4-light.png'),
+    dark: useBaseUrl('/assets/images/subnets/WEB-833_4-dark.png'),
+  }}
+/>
+
+When deleting a subnet with **Delete with Detailed Confirmation**, you can choose to move the associated IPs to the parent subnet (if one exists). This is useful when consolidating from a smaller subnet to a larger one without removing or recreating IP addresses.
+
+<ThemedImage
+  alt="Delete with Detailed Confirmation"
+  sources={{
+    light: useBaseUrl('/assets/images/subnets/WEB-833_5-light.png'),
+    dark: useBaseUrl('/assets/images/subnets/WEB-833_5-dark.png'),
+  }}
+/>
+
+### Create a Ping Sweep Job
+
+The **Actions** menu also includes an option for creating a ping sweep job for selected subnets.
+
+<ThemedImage
+  alt="Ping sweep action"
+  sources={{
+    light: useBaseUrl('/assets/images/subnets/ping-sweep-action-light.png'),
+    dark: useBaseUrl('/assets/images/subnets/ping-sweep-action-dark.png'),
+  }}
+/>
+
+Click the **View details** link on the green success message to see the details of the newly created ping sweep job. You can also view the job under **Discovery > Ping Sweep**.
+
+<ThemedImage
+  alt="View details link"
+  sources={{
+    light: useBaseUrl('/assets/images/subnets/ping-sweep-toast-link-light.png'),
+    dark: useBaseUrl('/assets/images/subnets/ping-sweep-toast-link-dark.png'),
+  }}
+/>
+
+Run the ad hoc ping sweep job immediately using the **Run Now** button on the details page.
+
+<ThemedImage
+  alt="Ad hoc ping sweep"
+  sources={{
+    light: useBaseUrl('/assets/images/subnets/adhoc-ping-sweep-light.png'),
+    dark: useBaseUrl('/assets/images/subnets/adhoc-ping-sweep-dark.png'),
+  }}
+/>
+
+## Add or Edit a Subnet
+
+Click **Create** to add a new subnet, or click an existing subnet name and then **Edit** to modify it.
+
+<ThemedImage
+  alt="Add or edit a subnet"
   sources={{
     light: useBaseUrl('/assets/images/subnets/WEB-833_6-light.png'),
     dark: useBaseUrl('/assets/images/subnets/WEB-833_6-dark.png'),
   }}
 />
 
-Network and mask bits are required fields; all others are optional. The range beginning and end are calculated automatically based on the network and mask bits if not entered.
+**Network** and **Mask Bits** are required fields; all others are optional. The range beginning and end are calculated automatically based on the network and mask bits if not entered.
 
-The VRF group is required if you want to further subnet this subnet.
+A VRF group is required if you want to further subnet this subnet.
 
-The Subnet Category can be used to categorize your subnets. If using the Multitenancy feature, you can restrict subnet permissions based on these categories.
+The **Subnet Category** field can be used to categorize your subnets. If you use the Multitenancy feature, you can restrict subnet permissions based on these categories.
 
-If you mark the network and/or broadcast addresses as usable for a subnet, these IPs will be shown as usable IPs in the IP Address list page.
+If you mark the network or broadcast addresses as usable for a subnet, these IPs will appear as usable on the IP address list page.
 
 ## VRF Groups and Overlapping Subnet Ranges
 
-When you add an overlapping subnet in a VRF group, the subnet gets automatically positioned with the right parent-child relationship.
+When you add an overlapping subnet within a VRF group, the subnet is automatically positioned with the correct parent-child relationship.
 
-## Adding Subnetted Subnets
+## Add Nested Subnets
+
+Once you assign a VRF group to a subnet and save, a **Subnets** tab appears in the lower part of the page.
 
 <ThemedImage
-  alt="Adding Subnetted Subnets"
+  alt="Add nested subnets"
   sources={{
     light: useBaseUrl('/assets/images/subnets/WEB-833_7-light.png'),
     dark: useBaseUrl('/assets/images/subnets/WEB-833_7-dark.png'),
   }}
 />
 
-Once you assign a VRF group to a subnet and save and continue, you will see a subnets tab in the lower part of the page.
+Enter the mask bits and click **Add** to automatically create a subnet underneath the current one. Error messages are displayed inline if there are any issues. Clicking on a nested subnet takes you to its edit page.
 
-You can just enter mask bits and click Add, and a subnet underneath the current subnet will be automatically created for you. It will show you error messages inline if there are any.
+## Relocate a Subnet
 
-On the edit page, clicking on a nested subnet takes you to the edit page for that subnet.
-
-## Relocating a Subnet
+Click **Relocate** on the subnet edit page to check whether the subnet can be moved into another subnet. If a valid parent is found and there are no IP conflicts, the subnet is relocated.
 
 <ThemedImage
-  alt="Relocating a subnet"
+  alt="Relocate a subnet"
   sources={{
     light: useBaseUrl('/assets/images/subnets/WEB-833_8-light.png'),
     dark: useBaseUrl('/assets/images/subnets/WEB-833_8-dark.png'),
   }}
 />
 
-On the edit page, if you click on **Relocate**, it will calculate whether there are any subnets into which this subnet can be moved. If it finds one and there are no IP conflicts, it will relocate the subnet.
+## Delete a Subnet or Merge Into Parent
 
-## Deleting a Subnet Upwards or Merging Into Parent
+The merge-to-parent function associates all child subnets and IPs with the parent subnet, then deletes the selected subnet.
 
 <ThemedImage
-  alt="Deleting a subnet upwards/merging into parent"
+  alt="Delete a subnet or merge into parent"
   sources={{
     light: useBaseUrl('/assets/images/subnets/WEB-833_9-light.png'),
     dark: useBaseUrl('/assets/images/subnets/WEB-833_9-dark.png'),
   }}
 />
-
-With the merge-to-parent function, you can associate all child subnets and IPs to a parent and delete that subnet, as shown in the image above.

--- a/docs/infrastructure-management/ipam/subnets.mdx
+++ b/docs/infrastructure-management/ipam/subnets.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Subnets"
-sidebar_position: 7
+sidebar_position: 3
 ---
 
 import ThemedImage from '@theme/ThemedImage'
@@ -41,7 +41,7 @@ Clicking on a subnet gives you a detailed view/edit page for that subnet.
 
 ### Actions: Deleting Subnets
 
-You can add IPs to an existing subnet using the new **Background Populate Subnets with IPs** command from the Subnet's **Actions** menu. 
+You can add IPs to an existing subnet using the new **Background Populate Subnets with IPs** command from the Subnet's **Actions** menu. 
 
 - When deleting a subnet (**Delete with Detailed Confirmation**), you can also choose to add the associated IPs to the parent subnet (if one exists). This feature helps when doing maintenance on subnets, where it is desirable to move from a smaller to a larger subnet without removing or recreating the associated IP addresses.
 
@@ -52,7 +52,7 @@ You can add IPs to an existing subnet using the new **Background Populate Subnet
       dark: useBaseUrl('/assets/images/subnets/WEB-833_3-dark.png'),
     }}
   />
- 
+ 
 
   <ThemedImage
     alt="Background Populate Subnets"

--- a/docs/infrastructure-management/ipam/subnets.mdx
+++ b/docs/infrastructure-management/ipam/subnets.mdx
@@ -8,7 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 A subnet can be any Layer 3 network (IPv4 or IPv6) in your organization, and it can optionally be part of a VLAN. All IP addresses in Device42 must belong to a subnet.
 
-You can create nested subnets automatically and relocate manually created subnets as nested subnets. The subnet must be part of a [VRF group](/infrastructure-management/ipam/vrf-groups) to create nested subnets. When you add an overlapping subnet within a VRF group, it is automatically positioned with the correct parent-child relationship.
+You can create nested subnets automatically and relocate manually created subnets as nested subnets. The subnet must be part of a [VRF group](infrastructure-management/ipam/vrf-groups.mdx) to create nested subnets. When you add an overlapping subnet within a VRF group, it is automatically positioned with the correct parent-child relationship.
 
 ## Subnet List Page
 

--- a/docs/infrastructure-management/ipam/switch-ports.mdx
+++ b/docs/infrastructure-management/ipam/switch-ports.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Switch Ports"
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/switch-ports.mdx
+++ b/docs/infrastructure-management/ipam/switch-ports.mdx
@@ -6,7 +6,7 @@ sidebar_position: 10
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-Switch ports can be discovered automatically using SNMP network discovery. You can also bulk add switch ports via [switch templates](switch-templates.mdx), or use the [Device42 RESTful APIs](https://api.device42.com/#/IPAM) to programmatically add or edit switch ports.
+Switch ports can be discovered automatically using SNMP network discovery. You can also bulk add switch ports via [switch templates](/infrastructure-management/ipam/switch-templates), or use the [Device42 RESTful APIs](https://api.device42.com/#/IPAM) to programmatically add or edit switch ports.
 
 ## Ports List Page
 
@@ -56,7 +56,7 @@ Switch ports include the following properties:
 - **Asset:** If the port is part of a FEX or similar asset connected to the switch, that association can be made here. You can assign a port to either a module or an asset.
 - **Network Switch 2nd:** For stacked switches, this is the clustered switch. For paired switches, this is the second switch through which the port can be managed.
 
-The **Module**, **Asset**, and **Network Switch 2nd** associations can be configured efficiently using [switch templates](switch-templates.mdx).
+The **Module**, **Asset**, and **Network Switch 2nd** associations can be configured efficiently using [switch templates](/infrastructure-management/ipam/switch-templates).
 
 - **Up:** Whether the port is up.
 - **Up Admin:** Whether the port is administratively up.
@@ -153,7 +153,7 @@ To add a new stacked switch hardware model, navigate to **Infrastructure > Hardw
 
 ## Represent FEX Modules
 
-FEX modules can be added as an asset and then associated with a switch using asset device relations. This is easier to configure using [switch templates](switch-templates.mdx).
+FEX modules can be added as an asset and then associated with a switch using asset device relations. This is easier to configure using [switch templates](/infrastructure-management/ipam/switch-templates).
 
 To add a new asset, navigate to **Resources > All Assets** and click **+ Create**. Name the asset and set **Type** to **Fabric Extender**.
 

--- a/docs/infrastructure-management/ipam/switch-ports.mdx
+++ b/docs/infrastructure-management/ipam/switch-ports.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Switch Ports"
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/switch-ports.mdx
+++ b/docs/infrastructure-management/ipam/switch-ports.mdx
@@ -6,15 +6,13 @@ sidebar_position: 10
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-Switch ports can be autodiscovered using SNMP network discovery. 
-
-You can bulk add switch ports via [switch templates](switch-templates.mdx), or use the [Device42 RESTful APIs](https://api.device42.com/#/IPAM) for an easy way to programmatically add or edit many switch ports at once.
+Switch ports can be discovered automatically using SNMP network discovery. You can also bulk add switch ports via [switch templates](switch-templates.mdx), or use the [Device42 RESTful APIs](https://api.device42.com/#/IPAM) to programmatically add or edit switch ports.
 
 ## Ports List Page
 
-From the main menu, navigate to **Resources > Network Devices > Ports**. 
+Navigate to **Resources > Network Devices > Ports** to view the ports list page.
 
-From the Ports list page, you can view and edit existing switch ports by clicking on any port ID. Add one or more new ports by clicking the **+ Create** button on the upper right:
+Click on any port ID to view and edit an existing switch port, or click **+ Create** to add a new port.
 
 <ThemedImage
   alt="Ports list page"
@@ -24,10 +22,10 @@ From the Ports list page, you can view and edit existing switch ports by clickin
   }}
 />
 
-You can also see a list of associated Ports via the **Ports** section on the device page:
+You can also see associated ports via the **Ports** section on a device page.
 
 <ThemedImage
-  alt="Switch Ports button on device page"
+  alt="Switch ports on device page"
   sources={{
     light: useBaseUrl('/assets/images/switch-ports/switch-ports-button-light.png'),
     dark: useBaseUrl('/assets/images/switch-ports/switch-ports-button-dark.png'),
@@ -48,30 +46,30 @@ Discovered ports use the **Is Default** property to indicate whether a port is t
 
 Switch ports include the following properties:
 
-**Port:** Name of the switch port as found during autodiscovery, or user-generated.  
-**Name:** As found in autodiscovery or user-generated.  
-**Description:** As found in autodiscovery or user-generated.  
-**Type:** Add the type of port. Use the **+ button** to add a new type.  
-**Network Device:** A device with network switch value as checked.  
-**VLANs:** All the VLANs this port belongs to. 
-**Module:** If this port is part of a module in a chassis-based switch, the module association can be made here.  
-**Asset:** If the port is part of FEX or a similar asset connected to the switch, that association can be made here. You can either assign it to a module or asset.  
-**Network Switch 2nd:** For stacked switches, this is the clustered switch. For paired switches, this is the second switch through which port can be managed.
+- **Port:** Name of the switch port as found during discovery, or user-generated.
+- **Name:** As found during discovery or user-generated.
+- **Description:** As found during discovery or user-generated.
+- **Type:** The type of port. Use the **+ button** to add a new type.
+- **Network Device:** A device with the network switch value checked.
+- **VLANs:** All the VLANs this port belongs to.
+- **Module:** If this port is part of a module in a chassis-based switch, the module association can be made here.
+- **Asset:** If the port is part of a FEX or similar asset connected to the switch, that association can be made here. You can assign a port to either a module or an asset.
+- **Network Switch 2nd:** For stacked switches, this is the clustered switch. For paired switches, this is the second switch through which the port can be managed.
 
-The associations for the Module, Asset, and the Network Switch 2nd fields can be done efficiently using [switch templates](switch-templates.mdx).
+The **Module**, **Asset**, and **Network Switch 2nd** associations can be configured efficiently using [switch templates](switch-templates.mdx).
 
-**Up:** Whether the port is up or not.  
-**Up admin:** Whether the port is administratively up or not. 
-**Count:** Count in the number of ports. 
-**Discovered type:** The port type as discovered during autodiscovery. This field is read-only. The discovered type value can be used to mark certain ports as uncounted, delete ports, or ignore certain port types in autodiscovery.  
-**Remote Port:** If the port is connected to another switch port, you can make that association here. This can be autodiscovered as well.  
-**Don't change via API:** If you override remote port connectivity manually, check this so autodiscovery or an API doesn't make this change automatically.  
-**Tags:** A comma-separated list of tags you would like attributed to the switch port. 
-**HW Address:** Any MAC addresses and devices connected to the switch port and the VLAN associated with the MAC address.
+- **Up:** Whether the port is up.
+- **Up Admin:** Whether the port is administratively up.
+- **Count:** Whether to count this port in the total.
+- **Discovered Type:** The port type as found during discovery. This field is read-only. The discovered type value can be used to mark certain ports as uncounted, delete ports, or ignore certain port types during discovery.
+- **Remote Port:** If the port is connected to another switch port, that association can be made here. This can also be discovered automatically.
+- **Don't Change Via API:** Check this if you override remote port connectivity manually, to prevent discovery or API calls from overwriting the change.
+- **Tags:** A comma-separated list of tags for the switch port.
+- **HW Address:** MAC addresses and devices connected to the switch port, and the VLAN associated with each MAC address.
 
 ## Add a New Switch Port
 
-Click the **+ Add Port** button on the upper right of the Ports list page and fill in the details of the port:
+Click **+ Add Port** on the ports list page and fill in the port details.
 
 <ThemedImage
   alt="Add new switch port"
@@ -81,20 +79,18 @@ Click the **+ Add Port** button on the upper right of the Ports list page and fi
   }}
 />
 
-Add more port details:
-
 <ThemedImage
-  alt="Add new switch port"
+  alt="Switch port additional details"
   sources={{
     light: useBaseUrl('/assets/images/switch-ports/add-port-2-light.png'),
     dark: useBaseUrl('/assets/images/switch-ports/add-port-2-dark.png'),
   }}
 />
 
-Scroll down to add **Port Aliases**, **Parts**, and see **Custom Fields**:
+Scroll down to add **Port Aliases**, **Parts**, and view **Custom Fields**.
 
 <ThemedImage
-  alt="Add new switch port"
+  alt="Port aliases and custom fields"
   sources={{
     light: useBaseUrl('/assets/images/switch-ports/add-port-3-light.png'),
     dark: useBaseUrl('/assets/images/switch-ports/add-port-3-dark.png'),
@@ -103,9 +99,9 @@ Scroll down to add **Port Aliases**, **Parts**, and see **Custom Fields**:
 
 ## Switch Port Bulk Operations
 
-Perform bulk operations by selecting ports from the table and choosing an action in the dropdown menu. Click the **icon hammer** to execute the action.
+Select ports from the table, choose an action from the dropdown menu, and click the **hammer icon** to execute it.
 
-For example, you can filter ports by up/down status, network switch, or discovered type, and select the ports to be not be counted in the total:
+For example, you can filter ports by up/down status, network switch, or discovered type, then select the ports to exclude from the count.
 
 <ThemedImage
   alt="Switch port action menu"
@@ -117,9 +113,9 @@ For example, you can filter ports by up/down status, network switch, or discover
 
 ## Switch Port Count
 
-In the rack layout view, the hover-over popup shows the total "counted" ports and up ports for that switch.  
+In the rack layout view, the hover-over popup shows the total counted ports and up ports for that switch.
 
-Also, from the switch port list page, you can filter by switch and up/down status to show the count of filtered ports.
+From the switch port list page, you can filter by switch and up/down status to show the count of filtered ports.
 
 <ThemedImage
   alt="Switch port count"
@@ -131,21 +127,21 @@ Also, from the switch port list page, you can filter by switch and up/down statu
 
 ## Switch Port Visualization
 
-For physical switches, click **Impact Chart** to see all the ports with connectivity, including each MAC-to-device relationship. Virtual devices are shown as 2nd layer devices that are connected to their vHost or marked with a '?' character if the vHost is unknown. 
+For physical switches, click **Impact Chart** to see all ports with connectivity, including each MAC-to-device relationship. Virtual devices are shown as second-layer devices connected to their vHost, or marked with `?` if the vHost is unknown.
 
 <ThemedImage
-  alt="Switch port impact chart example"
+  alt="Switch port impact chart"
   sources={{
     light: useBaseUrl('/assets/images/switch-ports/impact-chart-light.png'),
     dark: useBaseUrl('/assets/images/switch-ports/impact-chart-dark.png'),
   }}
 />
 
-## How Do I Represent a Stacked Switch?
+## Represent a Stacked Switch
 
-All switches, stacked or not, are represented according to their underlying hardware model. Stacked switches are represented by configuring their hardware model. To add an instance of a stacked switch, select the underlying hardware model that you created previously.
+All switches, stacked or not, are represented according to their underlying hardware model. To add an instance of a stacked switch, select the hardware model that you created previously.
 
-To add a new stacked switch, head to **Infrastructure > Hardware Models** and click **+ Create **. Create a new device hardware model by supplying a **Name**, **Physical Subtype**, and other basic information, and checking the **Network Device** checkbox. 
+To add a new stacked switch hardware model, navigate to **Infrastructure > Hardware Models** and click **+ Create**. Enter a **Name**, **Physical Subtype**, and other basic information, and check the **Network Device** checkbox.
 
 <ThemedImage
   alt="Add new hardware model"
@@ -157,9 +153,9 @@ To add a new stacked switch, head to **Infrastructure > Hardware Models** and cl
 
 ## Represent FEX Modules
 
-FEX modules can be added as an asset and then associated with the switch using asset device relations. This is easier to add using [switch templates](switch-templates.mdx).
+FEX modules can be added as an asset and then associated with a switch using asset device relations. This is easier to configure using [switch templates](switch-templates.mdx).
 
-To add a new asset, navigate to **Resources > All Assets** and click **+ Create**. Name the asset and under **Type** select **Fabric Extender**.  
+To add a new asset, navigate to **Resources > All Assets** and click **+ Create**. Name the asset and set **Type** to **Fabric Extender**.
 
 <ThemedImage
   alt="Add asset with Fabric Extender type"

--- a/docs/infrastructure-management/ipam/switch-ports.mdx
+++ b/docs/infrastructure-management/ipam/switch-ports.mdx
@@ -6,7 +6,7 @@ sidebar_position: 10
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-Switch ports can be discovered automatically using SNMP network discovery. You can also bulk add switch ports via [switch templates](/infrastructure-management/ipam/switch-templates), or use the [Device42 RESTful APIs](https://api.device42.com/#/IPAM) to programmatically add or edit switch ports.
+Switch ports can be discovered automatically using SNMP network discovery. You can also bulk add switch ports via [switch templates](infrastructure-management/ipam/switch-templates.mdx), or use the [Device42 RESTful APIs](https://api.device42.com/#/IPAM) to programmatically add or edit switch ports.
 
 ## Ports List Page
 
@@ -56,7 +56,7 @@ Switch ports include the following properties:
 - **Asset:** If the port is part of a FEX or similar asset connected to the switch, that association can be made here. You can assign a port to either a module or an asset.
 - **Network Switch 2nd:** For stacked switches, this is the clustered switch. For paired switches, this is the second switch through which the port can be managed.
 
-The **Module**, **Asset**, and **Network Switch 2nd** associations can be configured efficiently using [switch templates](/infrastructure-management/ipam/switch-templates).
+The **Module**, **Asset**, and **Network Switch 2nd** associations can be configured efficiently using [switch templates](infrastructure-management/ipam/switch-templates.mdx).
 
 - **Up:** Whether the port is up.
 - **Up Admin:** Whether the port is administratively up.
@@ -153,7 +153,7 @@ To add a new stacked switch hardware model, navigate to **Infrastructure > Hardw
 
 ## Represent FEX Modules
 
-FEX modules can be added as an asset and then associated with a switch using asset device relations. This is easier to configure using [switch templates](/infrastructure-management/ipam/switch-templates).
+FEX modules can be added as an asset and then associated with a switch using asset device relations. This is easier to configure using [switch templates](infrastructure-management/ipam/switch-templates.mdx).
 
 To add a new asset, navigate to **Resources > All Assets** and click **+ Create**. Name the asset and set **Type** to **Fabric Extender**.
 

--- a/docs/infrastructure-management/ipam/switch-templates.mdx
+++ b/docs/infrastructure-management/ipam/switch-templates.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Switch Templates"
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 import ThemedImage from '@theme/ThemedImage'
@@ -18,7 +18,7 @@ Switch templates can be used to create switches and switch ports using templates
 
 **Switch Templates – Legacy:** Create new switches and ports, or edit existing switches and ports.
 
-**Switch Templates 2.0:** Similar to Legacy, but port information is discovered from hardware models to auto-create ports. You can select the hardware models that you want to generate switches from and it will create them for you.  If your hardware model also has parts slots (for modular switches) then you will be able to populate the part models that you want to prepopulate those switches with. This is typically used when manually adding these hardware types and not relying on auto-discovery of switches.
+**Switch Templates 2.0:** Similar to Legacy, but port information is discovered from hardware models to auto-create ports. You can select the hardware models that you want to generate switches from and it will create them for you.  If your hardware model also has parts slots (for modular switches) then you will be able to populate the part models that you want to prepopulate those switches with. This is typically used when manually adding these hardware types and not relying on auto-discovery of switches.
 
 ## Switch Port Properties
 

--- a/docs/infrastructure-management/ipam/switch-templates.mdx
+++ b/docs/infrastructure-management/ipam/switch-templates.mdx
@@ -6,7 +6,7 @@ sidebar_position: 9
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-Switch templates can be used to create switches and switch ports using templates. Once you create the templates, you can either add/edit switch and switch ports using the UI or REST APIs.
+Switch templates let you define switch configurations as reusable blueprints for creating switches and their ports. Once you create a template, you can add or edit switches and switch ports using the UI or REST APIs.
 
 <ThemedImage
   alt="Switch template menu"
@@ -16,92 +16,94 @@ Switch templates can be used to create switches and switch ports using templates
   }}
 />
 
-**Switch Templates – Legacy:** Create new switches and ports, or edit existing switches and ports.
-
-**Switch Templates 2.0:** Similar to Legacy, but port information is discovered from hardware models to auto-create ports. You can select the hardware models that you want to generate switches from and it will create them for you.  If your hardware model also has parts slots (for modular switches) then you will be able to populate the part models that you want to prepopulate those switches with. This is typically used when manually adding these hardware types and not relying on auto-discovery of switches.
+- **Switch Templates – Legacy:** Create new switches and ports, or edit existing switches and ports.
+- **Switch Templates 2.0:** Similar to Legacy, but port information is derived from hardware models to auto-create ports. Select the hardware models you want to generate switches from and Device42 creates them for you. If a hardware model has parts slots (for modular switches), you can populate the part models to prepopulate those switches. This is typically used when manually adding hardware types rather than relying on discovery.
 
 ## Switch Port Properties
 
+The template defines extended properties for each port.
+
 <ThemedImage
-  alt="Switch template extended properties for switch port"
+  alt="Switch template port properties"
   sources={{
     light: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-extended-props-for-switch-port-1-light.png'),
     dark: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-extended-props-for-switch-port-1-dark.png'),
   }}
 />
 
-Module or Asset to show if a port belongs to a blade or fabric extender. Network switch 2nd would represent cluster switch in case of stacked switches or 2nd switch in case of paired switches.
+- **Module** or **Asset:** Indicates whether a port belongs to a blade or fabric extender.
+- **Network Switch 2nd:** Represents the cluster switch for stacked switches, or the second switch for paired switches.
 
 ## Switch Types
 
+Templates support singular, modular, distributed, stacked, and paired switch configurations.
+
 <ThemedImage
-  alt="Catering to different switch types in the templates"
+  alt="Switch type options"
   sources={{
     light: useBaseUrl('/assets/images/switch-templates/Catering_to_different_switch_types_in_the_templates-light.png'),
     dark: useBaseUrl('/assets/images/switch-templates/Catering_to_different_switch_types_in_the_templates-dark.png'),
   }}
-  style={{ width: '50%' }} 
+  style={{ width: '50%' }}
 />
-
-Whether the switch is singular, modular and/or distributed, you can add any type from the templates. Also, stacked switches and paired switches can be added. All different options are discussed below.
 
 ### Singular Switch
 
+For a simple switch, choose or add a hardware model and define the ports with port prefixes and counts. After saving, the list page displays a create/edit link next to the switch. Click it to choose an existing switch or enter a name for a new one, and the ports are created automatically.
+
 <ThemedImage
-  alt="Switch template singular switch"
+  alt="Singular switch template"
   sources={{
     light: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-singular-switch-2-light.png'),
     dark: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-singular-switch-2-dark.png'),
   }}
 />
 
-For a simple switch, you can choose (or add) the hardware module and add the ports in that switch with port prefixes. In example shown above, ports gbe/ 24 gig0/ and fiber/ 2 Fiber would be created (you can choose port starting number for each port template). Once you save this, on the list page it displays a create/edit link next to the switch. Once you click that you can choose an existing switch or add name for new one and rest is done automatically for you.
-
 ### Stacked Switches
 
+Stacked switches (for example, Cisco 3750s) let you add multiple singular switches to a stack. The stack is represented by a cluster device in Device42. All physical switches belong to the cluster device, and all ports have the cluster switch set as their **Network Switch 2nd** value.
+
 <ThemedImage
-  alt="Switch template stacked switch"
+  alt="Stacked switch template"
   sources={{
     light: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-stacked-switch-3-light.png'),
     dark: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-stacked-switch-3-dark.png'),
   }}
 />
 
-Taking a page from Cisco's 3750 switches, you can add multiple singular switches to the stack. Stack itself is represented by a cluster device in device42. All physical switches would belong to the cluster device and all ports would have switch2 as the cluster switch. Once you click on create switches, you would be presented with following screen.
+Click **Create Switches** to enter a name for the cluster device (or choose an existing one) and enter values for the switches in the stack. Switch ports and switches are created based on the template.
 
 <ThemedImage
-  alt="Switch template create/edit switch"
+  alt="Create stacked switches"
   sources={{
     light: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-createedit-switch-4-light.png'),
     dark: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-createedit-switch-4-dark.png'),
   }}
-  style={{ width: '70%' }} 
+  style={{ width: '70%' }}
 />
 
-Here you can enter a name for the cluster device(or choose an existing one) and similarly enter values for switches in the stack. Switch ports (and switches) are created based on the template.
+### Modular or Distributed Switch
 
-### Modular/Distributed Switch
+Use this type for modular or distributed switches, such as a Cisco 6509 with modules, or a Nexus 7K or 5K with fabric extender modules. Define modules with a hardware model, slot number, port prefixes, and port count. You can also add asset templates for fabric extenders. Device42 creates the switch, modules, assets, and switch ports based on the template values.
 
 <ThemedImage
-  alt="Switch template modular/distributed switch"
+  alt="Modular or distributed switch template"
   sources={{
     light: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-modulardistributed-switch-5-light.png'),
     dark: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-modulardistributed-switch-5-dark.png'),
   }}
-  style={{ width: '80%' }} 
+  style={{ width: '80%' }}
 />
 
-This type can be used to represent modular and/or distributed switches, e.g., a single 6509 switch with modules, Nexus 7k or Nexus 5k with fabric extender modules. Modules with hardware model, slot #, port prefixes and # of ports can be added here. You can also add asset templates( for Fabric Extenders) on this screen. Based on template values, you would be asked for switch/asset name etc. and it would create the switch, modules, assets(Fabric extenders) and switch ports based on the template.
+### Paired Modular or Distributed Switches
 
-### Paired Modular/Distributed Switches
+This template type covers paired switch configurations, such as Cisco VSS paired 6509s or two Nexus 5Ks running in active/active mode. Define port information and Device42 creates the modules, assets, and switch ports. Ports on the fabric extender can be marked to indicate whether they are connected to both switches or just one.
 
 <ThemedImage
-  alt="Switch template modular/paired switch"
+  alt="Paired modular switch template"
   sources={{
     light: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-modularpaired-switch-6-light.png'),
     dark: useBaseUrl('/assets/images/switch-templates/WEB-599_switch-template-modularpaired-switch-6-dark.png'),
   }}
-  style={{ width: '80%' }} 
+  style={{ width: '80%' }}
 />
-
-This template can serve few different use case scenarios. For example, Cisco VSS paired 6509s or 2 Nexus 5k running in active/active mode. You can add various port info, etc., and it will create modules/assets/switch ports. Ports on the fabric extender can be marked to show if they are connected to both the switches or just one.

--- a/docs/infrastructure-management/ipam/switch-templates.mdx
+++ b/docs/infrastructure-management/ipam/switch-templates.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Switch Templates"
-sidebar_position: 10
+sidebar_position: 9
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/switch-templates.mdx
+++ b/docs/infrastructure-management/ipam/switch-templates.mdx
@@ -49,7 +49,7 @@ Templates support singular, modular, distributed, stacked, and paired switch con
 
 ### Singular Switch
 
-For a simple switch, choose or add a hardware model and define the ports with port prefixes and counts. After saving, the list page displays a create/edit link next to the switch. Click it to choose an existing switch or enter a name for a new one, and the ports are created automatically.
+For a simple switch, choose or add a hardware model and define the ports with port prefixes, counts, and starting numbers. For example, port templates `gbe/` with 24 ports and `fiber/` with 2 ports would create `gbe/` and `fiber/` ports accordingly. After saving, the list page displays a create/edit link next to the switch. Click it to choose an existing switch or enter a name for a new one, and the ports are created automatically.
 
 <ThemedImage
   alt="Singular switch template"

--- a/docs/infrastructure-management/ipam/vlans.mdx
+++ b/docs/infrastructure-management/ipam/vlans.mdx
@@ -6,13 +6,13 @@ sidebar_position: 2
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-View and manage VLANs discovered by Device42 or add them manually.
+VLANs (virtual LANs) are Layer 2 network segments that logically divide a physical network. View and manage VLANs discovered by Device42 or add them manually.
 
 ## VLAN List Page
 
-Locate the VLAN list page under **Resources > Subnets > VLANs**.
+Navigate to **Resources > Networks > VLANs** to view the VLAN list page.
 
-The list page displays all of the L2 VLANs that have been defined, along with all the switches that each VLAN is on. As with any list in the Device42 portal, you can sort by multiple fields, search by VLAN **Number** or **Name**, and click on an individual VLAN to open the details page for that VLAN.
+The list page displays all L2 VLANs that have been defined, along with all the switches that each VLAN is on. You can sort by multiple fields, search by VLAN **Number** or **Name**, and click on an individual VLAN to open its details page.
 
 <ThemedImage
   alt="VLAN list page"
@@ -24,10 +24,10 @@ The list page displays all of the L2 VLANs that have been defined, along with al
 
 ### Add a New VLAN
 
-The VLAN number is the only required field in this form. The name is automatically calculated as `VLANxxxx` if not entered. You can associate multiple switches with a VLAN.
+The VLAN number is the only required field. The name is automatically set to `VLANxxxx` if not entered. You can associate multiple switches with a VLAN.
 
 <ThemedImage
-  alt="Adding a new VLAN"
+  alt="Add a new VLAN"
   sources={{
     light: useBaseUrl('/assets/images/vlans/wpid4653-media_1328979126014-light.png'),
     dark: useBaseUrl('/assets/images/vlans/wpid4653-media_1328979126014-dark.png'),
@@ -36,26 +36,26 @@ The VLAN number is the only required field in this form. The name is automatical
 
 ## Merge Discovered VLANs
 
-With VLAN autodiscovery, all VLANs are pulled into Device42 from each switch that is discovered. During the discovery process, the system does not assume that matching VLAN numbers from different switches are the same VLAN. It is common to have duplicate VLANs after running autodiscovery. While most duplicate VLANs are actually the same VLAN, it is not always true. 
+During VLAN discovery, all VLANs are pulled into Device42 from each switch. The system does not assume that matching VLAN numbers from different switches are the same VLAN, so it is common to have duplicates after running discovery. While most duplicate VLANs are actually the same VLAN, this is not always the case.
 
-The **Merge selected Vlans** bulk action is available to address this by merging duplicate VLANs. There are two approaches to merging VLANs:
+The **Merge selected Vlans** bulk action addresses this by merging duplicate VLANs. There are two approaches:
 
 <ThemedImage
-  alt="Merging auto-discovered VLANs"
+  alt="Merging discovered VLANs"
   sources={{
     light: useBaseUrl('/assets/images/vlans/wpid4656-Merging_auto-discovered_VLANs-light.png'),
     dark: useBaseUrl('/assets/images/vlans/wpid4656-Merging_auto-discovered_VLANs-dark.png'),
   }}
 />
 
-1. Select a specific subset of VLANs you wish to merge: For example, if VLAN #42 were discovered on 10 different switches and you knew each instance was the same VLAN, it should be merged. You would select the VLANs you want to merge, choose **Merge selected Vlans** from the **Actions** dropdown menu.
+- **Merge specific VLANs:** For example, if VLAN #42 was discovered on 10 different switches and you know each instance is the same VLAN, select those VLANs and choose **Merge selected Vlans** from the **Actions** dropdown menu.
 
-2. Select all the VLANs in Device42 and let the system merge all matching VLAN numbers to eliminate duplicates: Select all VLANs on the list, then choose **Smart Merge selected Vlans** from the **Actions** dropdown menu.
+- **Smart merge all VLANs:** Select all VLANs on the list, then choose **Smart Merge selected Vlans** from the **Actions** dropdown menu to automatically merge all matching VLAN numbers.
 
-### What happens when VLANs are merged?
+### What Happens When VLANs Are Merged?
 
-Duplicate VLAN numbers are eliminated, and all subnets, switch ports, and MAC addresses are consolidated into and associated with the merged VLAN.
+Duplicate VLAN numbers are eliminated, and all subnets, switch ports, and MAC addresses are consolidated into the merged VLAN.
 
-### Does a VLAN merge prevent future duplicate VLANs?
+### Does a VLAN Merge Prevent Future Duplicates?
 
-Yes, but with one exception: VLANs on any newly discovered switches will be pulled in as unique VLANs. If this occurs, simply merge the newly discovered VLAN using the approach outlined above.
+Yes, with one exception: VLANs on any newly discovered switches are pulled in as unique VLANs. If this occurs, merge the newly discovered VLAN using the same approach.

--- a/docs/infrastructure-management/ipam/vlans.mdx
+++ b/docs/infrastructure-management/ipam/vlans.mdx
@@ -1,6 +1,6 @@
 ---
 title: "VLANs"
-sidebar_position: 10
+sidebar_position: 2
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/vrf-groups.mdx
+++ b/docs/infrastructure-management/ipam/vrf-groups.mdx
@@ -1,6 +1,6 @@
 ---
 title: "VRF Groups"
-sidebar_position: 11
+sidebar_position: 1
 ---
 
 import ThemedImage from '@theme/ThemedImage'

--- a/docs/infrastructure-management/ipam/vrf-groups.mdx
+++ b/docs/infrastructure-management/ipam/vrf-groups.mdx
@@ -6,21 +6,23 @@ sidebar_position: 1
 import ThemedImage from '@theme/ThemedImage'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-Virtual routing and forwarding groups (VRF groups) are often used by ISPs and other larger network service providers to organize and track customers' (or their own) logical networks segments, subnets, and VLANs, some of which often overlap with IP ranges in use in other VRF groups - _but never within the same VRF group_. The reason why is quite simple: There are really only three IP address ranges dedicated to private network use: 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16; however, there are thousands of end users on these networks that need to route traffic to the internet - and in a few special cases, to each other. VRF groups to the rescue!
+Virtual routing and forwarding groups (VRF groups) are often used by ISPs and other larger network service providers to organize and track their logical network segments, subnets, and VLANs, some of which often overlap with IP ranges in use in other VRF groups — but never within the same VRF group. The reason is straightforward: there are really only three IP address ranges dedicated to private network use (`10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`), yet there are thousands of end users on these networks that need to route traffic to the internet, and in a few special cases, to each other. That's where VRF groups come in.
 
-Most VRF groups are designed so that they can't route between each other by default; however, all are able to route out to a larger network cloud (for example, the internet), thus allowing multiple customers to assign IP addresses to end users on their own networks as they please - without interfering with one another.
+Most VRF groups are designed so that they can't route between each other by default. However, all are able to route out to a larger network cloud (for example, the internet), allowing multiple customers to assign IP addresses to end users on their own networks as they please, without interfering with one another.
 
 <ThemedImage
-  alt="Device42 VRF Group menu item"
+  alt="VRF group menu item"
   sources={{
     light: useBaseUrl('/assets/images/vrf-groups/VRF_Group_menu-light.png'),
     dark: useBaseUrl('/assets/images/vrf-groups/VRF_Group_menu-dark.png'),
   }}
 />
 
-Device42 users can create VRF groups in Device42 to track and manage these overlapping IP Ranges via the main menu, **Network > VRF Group**. Simply assign networks to VRF groups as appropriate, dividing your individual networks into VRF groups. IP addresses must be unique _per VRF group_, but _you can have overlapping subnet ranges_ across VRF groups.
+Create VRF groups in Device42 via **Resources > Networks > VRF Group**. Assign networks to VRF groups as appropriate, dividing your individual networks into VRF groups. IP addresses must be unique per VRF group, but you can have overlapping subnet ranges across VRF groups.
 
-## Add/Edit a VRF Group Page
+## Add or Edit a VRF Group
+
+Click **Create** to add a new VRF group, or click an existing VRF group name and then **Edit** to modify it.
 
 <ThemedImage
   alt="Add new VRF group"
@@ -30,20 +32,20 @@ Device42 users can create VRF groups in Device42 to track and manage these overl
   }}
 />
 
-**Name:** is required and must be unique among VRF groups.  
-**Description:** Free form text to enter any text.  
-**Default:** Select this checkbox to have all subnets auto-discovered added to this VRF group automatically (going forward). This option will not add existing subnets automatically. _Note that subnets are not displayed on the edit page._
+- **Name:** Required and must be unique among VRF groups.
+- **Description:** Free-form text field for any additional details.
+- **Default:** Select this checkbox to have all newly discovered subnets added to this VRF group automatically. This does not apply to existing subnets.
 
-If you make the VRF group the default, then subnets and IPs will be automatically assigned to this default VRF group - unless otherwise specified.
+If you set a VRF group as the default, subnets and IPs are automatically assigned to it unless otherwise specified.
 
 ## View an Existing VRF Group
 
 <ThemedImage
-  alt="Select VRF group to view"
+  alt="VRF group list page"
   sources={{
     light: useBaseUrl('/assets/images/vrf-groups/select_VRF_to_view-light.png'),
     dark: useBaseUrl('/assets/images/vrf-groups/select_VRF_to_view-dark.png'),
   }}
 />
 
-The VRF Group view page shows all of your VRF Groups.
+The VRF group list page shows all your VRF groups.

--- a/docs/infrastructure-management/ipam/vrf-groups.mdx
+++ b/docs/infrastructure-management/ipam/vrf-groups.mdx
@@ -48,4 +48,4 @@ If you set a VRF group as the default, subnets and IPs are automatically assigne
   }}
 />
 
-The VRF group list page shows all your VRF groups.
+The list page shows all defined VRF groups with their associated subnets and details.


### PR DESCRIPTION

| Jira issue | Description | Preview link(s) |
| --- | --- | --- |
| 1237 | Grammar, structure, and sidebar reorder; IPAM pages | - [IPAM](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam)<br>- [VRF Groups](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/vrf-groups)<br>- [VLANs](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/vlans)<br>- [Subnets](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/subnets)<br>- [Subnet Tree View](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/subnet-tree-view)<br>- [IP Addresses](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/ip-addresses)<br>- [IP NAT/Map](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/ip-nat-map)<br>- [DNS Zones](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/dns-zones)<br>- [DNS Records](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/dns-records)<br>- [Switch Templates](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/switch-templates)<br>- [Switch Ports](https://preview.ritza.co/device42/ipam-improvements/infrastructure-management/ipam/switch-ports) |

**Sidebar reordered** to flow from foundational concepts to specific features, so readers encounter building blocks before the things that depend on them:

1. VRF Groups
2. VLANs
3. Subnets
4. Subnet Tree View
5. IP Addresses
6. IP NAT/Map
7. DNS Zones
8. DNS Records
9. Switch Templates
10. Switch Ports

