### PR TITLE
hide feedback button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,13 +19,14 @@ const config = {
 
   // Load the Feedback Rocket SDK on every page
   scripts: [
-    {
-      async: true,
-      src: 'https://www.feedbackrocket.io/sdk/v1.1.js',
-      'data-fr-id': 'ZGuyxqZHGoYVrmt3nYmF2',
-      'data-fr-reply': "",
-      'data-fr-theme': 'dynamic',
-    },
+    // Temporarily disabled: Feedback Rocket SDK
+    // {
+    //   async: true,
+    //   src: 'https://www.feedbackrocket.io/sdk/v1.1.js',
+    //   'data-fr-id': 'ZGuyxqZHGoYVrmt3nYmF2',
+    //   'data-fr-reply': "",
+    //   'data-fr-theme': 'dynamic',
+    // },
     {
       src: 'https://cdn-ukwest.onetrust.com/scripttemplates/otSDKStub.js',
       'data-domain-script': '018fa3d5-077b-79ba-acca-d22007888127',
@@ -1310,14 +1311,15 @@ const config = {
             label: 'Company',
             position: 'right',
           },
-          {
-            type: 'html',
-            position: 'right', value:
-              `<a href=# class=navbar__button data-fr-widget>
-                Page feedback
-              </a>`,
-
-          },
+          // Temporarily disabled: Feedback Rocket "Page feedback" button
+          // {
+          //   type: 'html',
+          //   position: 'right', value:
+          //     `<a href=# class=navbar__button data-fr-widget>
+          //       Page feedback
+          //     </a>`,
+          //
+          // },
          ],
       },
       prism: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -89,3 +89,9 @@ main {
   text-decoration: none;
   opacity: 0.85;
 }
+
+/* Make the gap before the theme toggle (Company → sun icon) match the
+   gap after it (sun icon → search bar). */
+.toggleButton_node_modules-\@docusaurus-theme-classic-lib-theme-ColorModeToggle-styles-module {
+  margin-left: 0.85em;
+}


### PR DESCRIPTION
Hide the Page Feedback button from the nav bar until Feedback Rocket or equivalent is working again. 
<img width="1484" height="162" alt="CleanShot 2026-06-08 at 15 52 40" src="https://github.com/user-attachments/assets/9a4fdbca-4f61-437c-9486-a94cbc81c7e6" />
